### PR TITLE
Update to clear_callback to store address of null_handler correctly

### DIFF
--- a/src/zsmplayer.asm
+++ b/src/zsmplayer.asm
@@ -903,7 +903,7 @@ done:		rts
 			lda #<null_handler
 			sta ZSM_VECTOR_notify
 			lda #>null_handler
-			sta ZSM_VECTOR_notify
+			sta ZSM_VECTOR_notify+1
 			cli
 			rts
 .endproc


### PR DESCRIPTION
clear_callback wrote both the MSB and LSB of the null_handler to a single byte ZSM_VECTOR_notify.
Edited it so MSB is written to ZSM_VECTOR_notify+1