### PR TITLE
Make all zsmplayer calls safe to call from within IRQ (preserve interrupt flag).  Avoid clobbering r0/r1

### DIFF
--- a/src/zsmplayer.asm
+++ b/src/zsmplayer.asm
@@ -35,8 +35,6 @@ delay:		.res	1
 ; these next two probably need to use TMP ZP space, not permanent.....
 fracstep:	.res	1			; residual steps per frame
 step:			.res	2			; integer steps per frame
-tmp0:	.res 2
-tmp1:   .res 1
 
 .segment "BSS"
 
@@ -481,10 +479,15 @@ die:
 ;
 .proc set_music_speed: near
 			; X/Y = tick rate (Hz) - divide by 60 and store to zsm_steps
-			; use the ZP variable as tmp space
+			lda data
+			pha
+			lda data+1
+			pha
+			lda data+2
+			pha
 
-			value := tmp0
-			frac  := tmp1
+			value := data
+			frac  := data+2
 			stx value
 			sty value+1
 			stz frac
@@ -528,6 +531,12 @@ hz_to_tickrate:
 			adc #0
 			sta zsm_steps+1
 setplayer:
+			pla
+			sta data+2
+			pla
+			sta data+1
+			pla
+			sta data
 			CHOOSE_PLAYER
 			rts
 

--- a/src/zsmplayer.asm
+++ b/src/zsmplayer.asm
@@ -479,15 +479,16 @@ die:
 ;
 .proc set_music_speed: near
 			; X/Y = tick rate (Hz) - divide by 60 and store to zsm_steps
-			lda data
+			; use r0/r1 ZP as temp space, but preserve it
+			lda r0L
 			pha
-			lda data+1
+			lda r0H
 			pha
-			lda data+2
+			lda r1L
 			pha
 
-			value := data
-			frac  := data+2
+			value := r0
+			frac  := r1L
 			stx value
 			sty value+1
 			stz frac
@@ -532,11 +533,11 @@ hz_to_tickrate:
 			sta zsm_steps+1
 setplayer:
 			pla
-			sta data+2
+			sta r1
 			pla
-			sta data+1
+			sta r0H
 			pla
-			sta data
+			sta r0L
 			CHOOSE_PLAYER
 			rts
 


### PR DESCRIPTION
Both of these issues frustrated my initial implementation.  For better or worse, NES games run almost 100% of their game code in the interrupt handler, so it's friendlier for the scenario of porting an NES game, or if interrupts are disabled for another reason, not to ever explicitly call CLI.

r0/r1 clobber is problematic 1) due to ZP being unusually tight in my project, and the fact that its use was not clearly indicated.
I think preserving r0/r1 is still faster than using absolute addressing in this routine.

