### PR TITLE
Extra NOPs needed for YM2164

### DIFF
--- a/src/zsmplayer.asm
+++ b/src/zsmplayer.asm
@@ -633,6 +633,11 @@ YMloop:
 			nop
 			nop
 			nop
+			nop
+			nop
+			nop
+			nop
+			nop
 			sty YM_data		; restore value from before pause
 nextYM:		inx
 			inc
@@ -709,9 +714,19 @@ YMloop:		ror zsm_chanmask
 			nop
 			nop
 			nop
+			nop
+			nop
+			nop
+			nop
+			nop
 			stx	YM_data		; send KeyUP for voice
 			YM_BUSY_WAIT
 			sta YM_reg		; select LR|FB|CON register for voice
+			nop
+			nop
+			nop
+			nop
+			nop
 			nop
 			nop
 			nop
@@ -851,6 +866,11 @@ noYMshadow:
 			lda (data),y
 			YM_BUSY_WAIT
 			stx YM_reg
+			nop
+			nop
+			nop
+			nop
+			nop
 			nop
 			nop
 			nop

--- a/src/zsmplayer.asm
+++ b/src/zsmplayer.asm
@@ -630,14 +630,9 @@ YMloop:
 			ldy ym_rl_fb_con_shadow,x
 			YM_BUSY_WAIT
 			sta YM_reg		; select LR|FB|CON register for voice
+.repeat 9
 			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
+.endrepeat
 			sty YM_data		; restore value from before pause
 nextYM:		inx
 			inc
@@ -711,25 +706,15 @@ YMloop:		ror zsm_chanmask
 			YM_BUSY_WAIT
 			ldy #08
 			sty YM_reg
+.repeat 9
 			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
+.endrepeat
 			stx	YM_data		; send KeyUP for voice
 			YM_BUSY_WAIT
 			sta YM_reg		; select LR|FB|CON register for voice
+.repeat 9
 			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
+.endrepeat
 			stz YM_data		; set to 0 to disable L and R output
 nextYM:		inx
 			inc
@@ -866,14 +851,9 @@ noYMshadow:
 			lda (data),y
 			YM_BUSY_WAIT
 			stx YM_reg
+.repeat 9
 			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
-			nop
+.endrepeat
 			sta YM_data
 			ldx shadow_offset
 			beq :+


### PR DESCRIPTION
Due to availability of YM2151s not being what had been anticipated, X16s may be shipped with YM2164s (OPP) which are in large part compatible.

However, it was discovered that they need more clocks in between writes to the address register and to the data register.  The existing 3 nops drops a lot of writes.  5 nops is a lot better but some still drop.  8 nops seems to be enough.