### PR TITLE
Patch $lfotable

### DIFF
--- a/tools/vgm2zsm
+++ b/tools/vgm2zsm
@@ -1002,8 +1002,8 @@ while ($i < EOF) {
 		DEBUG("2612LFO: reg 0x22 written with value 0x%02x\n",$d);
 		// LFO speeds: 3.98, 5.56, 6.02, 6.37,
 		//             6.88, 9.63, 48.1, 72.2
-		$lfotable = array ( 0xc2, 0xca, 0xcc, 0xce,
-							0xd0, 0xd7, 0xfc, 0xff );
+		$lfotable = array ( 0xc2, 0xc9, 0xcb, 0xcd,
+							0xcf, 0xd6, 0xfb, 0xff );
 		if (($d & 0x08) > 0) { $d = $lfotable[$d & 0x07]; }
 		else { $d = 0; }
 		$a = 0x18;


### PR DESCRIPTION
Hi!

Thank you for all your contributions to x16community! Been using your works for quite a long time, mainly the ZSM. And it's great to hear that you're easing back into retro stuff lately.

With massive help from MooingLemur, and me riding the short bus along, it could be determined that the lfotable used in your vgm2zsm code is inaccurate.

It's my belief, infer from the values you wrote, that you're refencing Yamaha's OPN2 datasheet when creating this LUT, which uses a 8mhz clock as phiM. 

However, the actual clock of OPN2 on SEGA MD/Genisis is 7.670453 MHz (NTSC), 7.600489 MHz (PAL), which skewed the LFO speed quite a bit.

Here's a reference at 7.6ish mhz
![image](https://github.com/ZeroByteOrg/zsound/assets/76813695/b885bed2-5fb3-4d89-83c3-02a0d37b38a9)

And a reference at 8mhz
![image](https://github.com/ZeroByteOrg/zsound/assets/76813695/c1f5d996-86a6-4c23-9918-c33209455c4e)


considering most song using OPN2 would targeting MD, I believe we can make this conversion more accurate easily by modify Line 1005 1006.

With extensive helps from ML, here's the cycle accurate LFO speed val.


[YM2151 LFO.xlsx](https://github.com/ZeroByteOrg/zsound/files/15326594/YM2151.LFO.xlsx)


hence, the new lfotable should be 
$lfotable = array ( 0xc2, 0xC9, 0xCB, 0xCD, 0xCF, 0xD6, 0xFB, 0xff );


Thank you for all your dedications!